### PR TITLE
add shell highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ attr type if a tuple of the form:
 
 You can definitely parse a complete XML structure with `fast_xml`:
 
-```
+```shell
 $ erl -pa ebin
 Erlang/OTP 17 [erts-6.3] [source] [64-bit] [smp:4:4] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]
 
@@ -91,7 +91,7 @@ own application.
 
 Here is an example XML stream parsing:
 
-```
+```shell
 $ erl -pa ebin
 Erlang/OTP 17 [erts-6.3] [source] [64-bit] [smp:4:4] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]
 


### PR DESCRIPTION
It seemed like the examples would be easier to read with highlighting.