### PR TITLE
Add p1_utils to applications

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,9 @@ defmodule FastXML.Mixfile do
   end
 
   def application do
-    [mod: {:fast_xml, []}]
+    [ mod: {:fast_xml, []},
+      applications: [:p1_utils]
+    ]
   end
 
   defp package do


### PR DESCRIPTION
This is required for exrm releases, otherwise `p1_utils` is not included in the release or the end user is required to add it to their own `applications`

I matched the style of `project` even though it's somewhat non-standard. Let me know if you'd like me to tweak the style.