### PR TITLE
build: add FreeBSD NIF build code

### DIFF
--- a/Makefile.mix
+++ b/Makefile.mix
@@ -15,9 +15,14 @@ ifneq ($(OS),Windows_NT)
 		LDFLAGS += -dynamiclib -undefined dynamic_lookup
 	endif
 
-        ifeq ($(shell uname),Linux)
+	ifeq ($(shell uname),FreeBSD)
+		CFLAGS  += -I/usr/local/include
+		LDFLAGS += -L/usr/local/lib
+	endif
+
+	ifeq ($(shell uname),Linux)
 		LDFLAGS += -shared -L$(ERL_INTERFACE_PATH) -lerl_interface -lei
-        endif
+	endif
 endif
 
 .PHONY: all fast_xml clean

--- a/mix.exs
+++ b/mix.exs
@@ -18,10 +18,10 @@ defmodule FastXML.Mixfile do
   def project do
     [ app: :fast_xml,
       description: "Fast Expat-based Erlang / Elixir XML parsing library",
-      version: "1.1.12",
-      elixir: "~> 1.2",
-      compilers: [:fastXML | Mix.compilers],
-      aliases: aliases,
+      version: "1.1.13",
+      elixir: "~> 1.3",
+      compilers: [:elixir_make | Mix.compilers],
+      make_makefile: "Makefile",
       deps: deps,
       package: package
     ]
@@ -44,45 +44,9 @@ defmodule FastXML.Mixfile do
 
   def deps do
     [{:p1_utils, "~> 1.0"},
+     {:elixir_make, "~> 0.4", runtime: false},
      {:earmark, "~> 0.1", only: :dev},
      {:ex_doc, "~> 0.11", only: :dev},
      {:eqc_ex, "~> 1.2", only: :test}]
-  end
-
-  defp aliases do
-    # Execute the usual mix clean and our Makefile clean task
-    [clean: ["clean", "clean.fastXML"]]
-  end
-end
-
-# Define
-defmodule Mix.Tasks.Compile.FastXML do
-  @shortdoc "Compiles helper in c_src"
-
-  # TODO refactor
-  def run(_) do
-    if match? {:win32, _}, :os.type do
-      {result, _error_code} = System.cmd("nmake", ["/F", "Makefile.mix", "priv\\lib\\fxml_stream.dll"], stderr_to_stdout: true)
-      Mix.shell.info result
-      {result, _error_code} = System.cmd("nmake", ["/F", "Makefile.mix", "priv\\lib\\fxml.dll"], stderr_to_stdout: true)
-      Mix.shell.info result
-    else
-      {result, _error_code} = System.cmd("make", ["-f", "Makefile.mix", "priv/lib/fxml_stream.so"], stderr_to_stdout: true)
-      Mix.shell.info result
-      {result, _error_code} = System.cmd("make", ["-f", "Makefile.mix", "priv/lib/fxml.so"], stderr_to_stdout: true)
-      Mix.shell.info result
-    end
-    Mix.Project.build_structure
-  end
-end
-
-defmodule Mix.Tasks.Clean.FastXML do
-  @shortdoc "Cleans helper in c_src"
-
-  def run(_) do
-    {result, _error_code} = System.cmd("make", ["-f", "Makefile.mix", "clean"], stderr_to_stdout: true)
-    Mix.shell.info result
-
-    :ok
   end
 end

--- a/rebar.config
+++ b/rebar.config
@@ -21,10 +21,13 @@
 %%%----------------------------------------------------------------------
 
 {erl_opts, [debug_info,
-	    {src_dirs, ["src"]},
-	    {platform_define, "^(15|16|17|18)", 'HAVE_REMOTE_TYPES'},
-	    {platform_define, "^(15|16|17)", 'HAVE_FROM_FORM0'}]}.
-{port_env, [{"CFLAGS", "$CFLAGS"}, {"LDFLAGS", "$LDFLAGS"}]}.
+            {src_dirs, ["src"]},
+            {platform_define, "^(15|16|17|18)", 'HAVE_REMOTE_TYPES'},
+            {platform_define, "^(15|16|17)", 'HAVE_FROM_FORM0'}]}.
+{port_env, [{"CFLAGS", "$CFLAGS"}, {"LDFLAGS", "$LDFLAGS"},
+            {"freebsd", "CFLAGS",  "$CFLAGS -I/usr/local/include"},
+             {"freebsd","LDFLAGS", "$LDFLAGS -L/usr/local/lib"}]}.
+
 {port_specs, [{"priv/lib/fxml.so", ["c_src/fxml.c"]},
               {"priv/lib/fxml_stream.so", ["c_src/fxml_stream.c"]}]}.
 


### PR DESCRIPTION
it turns out that https://github.com/elixir-lang/elixir_make indeed makes things simpler, and most of the custom P1 workarounds can now be dropped. I can't test on Windows BTW.