### PR TITLE
p1_utils in app.src

### DIFF
--- a/src/fast_xml.app.src
+++ b/src/fast_xml.app.src
@@ -26,7 +26,7 @@
   {vsn,          "1.1.29"},
   {modules,      []},
   {registered,   []},
-  {applications, [kernel, stdlib]},
+  {applications, [kernel, stdlib, p1_utils]},
   {mod,          {fast_xml,[]}},
 
   %% hex.pm packaging:


### PR DESCRIPTION
Problem statements:
`relx` uses the `app.src` for resolving dependencies, but `fast_xml.app.src` doesn't include `p1_utils` in applications list, so `relx` makes invalid release.
