### PR TITLE
fix detecting rebar3 and build with relx

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -30,12 +30,10 @@ Cfg = case file:consult(filename:join([filename:dirname(SCRIPT),"vars.config"]))
 {ldflags, CfgLDFlags} = lists:keyfind(ldflags, 1, Cfg),
 {with_gcov, CfgWithGCov} = lists:keyfind(with_gcov, 1, Cfg),
 
-IsRebar3 = case application:get_key(rebar, vsn) of
-	       {ok, VSN} ->
-		   [VSN1 | _] = string:tokens(VSN, "-"),
-		   [Maj|_] = string:tokens(VSN1, "."),
-		   (list_to_integer(Maj) >= 3);
-	       undefined ->
+IsRebar3 = case erlang:function_exported(rebar3, main, 1) of
+	       true ->
+		   true;
+	       _ ->
 		   lists:keymember(mix, 1, application:loaded_applications())
 	   end,
 

--- a/src/fast_xml.app.src
+++ b/src/fast_xml.app.src
@@ -26,7 +26,7 @@
   {vsn,          "1.1.29"},
   {modules,      []},
   {registered,   []},
-  {applications, [kernel, stdlib]},
+  {applications, [kernel, stdlib, p1_utils]},
   {mod,          {fast_xml,[]}},
 
   %% hex.pm packaging:


### PR DESCRIPTION
this makes rebar3 detection more stable in various environments.
also contains #33 

the `mix` thing can be frankly removed too and `erlang:function_exported(rebar3, main, 1)` should be enough for mix . But I do not have an env to validate that is in fact true. 

@prefiks will appreciate if you take a look. 
Thanks