### PR TITLE
Support making specs with OTP 21

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -24,7 +24,7 @@
             {src_dirs, ["src"]},
             {platform_define, "^(15|16|17|18)", 'HAVE_REMOTE_TYPES'},
             {platform_define, "^(15|16|17)", 'HAVE_FROM_FORM0'},
-	    {platform_define, "^(19\\.3|20)", 'USE_MAPS'}]}.
+	    {platform_define, "^(15|16|17|18|19\\.0|19\\.1|19\\.2)", 'USE_DICT'}]}.
 {port_env, [{"CFLAGS", "$CFLAGS"}, {"LDFLAGS", "$LDFLAGS"},
             {"freebsd", "CFLAGS",  "$CFLAGS -I/usr/local/include"},
              {"freebsd","LDFLAGS", "$LDFLAGS -L/usr/local/lib"}]}.

--- a/src/fxml_gen.erl
+++ b/src/fxml_gen.erl
@@ -2750,14 +2750,14 @@ t_remote(Mod, Type) ->
     T.
 -endif.
 
--ifdef(USE_MAPS).
-dict_from_list(L) ->
-    maps:from_list(L).
-dict_keys(D) ->
-    maps:keys(D).
--else.
+-ifdef(USE_DICT).
 dict_from_list(L) ->
     dict:from_list(L).
 dict_keys(D) ->
     dict:fetch_keys(D).
+-else.
+dict_from_list(L) ->
+    maps:from_list(L).
+dict_keys(D) ->
+    maps:keys(D).
 -endif.


### PR DESCRIPTION
Add OTP 21 to list of platforms that use maps instead of dicts to
allow 'make spec' in xmpp lib to work again