### PR TITLE
Update hex packaged files

### DIFF
--- a/src/fast_xml.app.src
+++ b/src/fast_xml.app.src
@@ -30,7 +30,7 @@
   {mod,          {fast_xml,[]}},
 
   %% hex.pm packaging:
-  {files, ["src/", "lib/", "c_src/fxml.c", "c_src/fxml_stream.c", "include/", "priv/lib/.keepme", "mix.exs", "mix.lock", "Makefile.mix", "rebar.config", "rebar.config.script", "README.md", "LICENSE.txt"]},
+  {files, ["src/", "lib/", "c_src/fxml.c", "c_src/fxml_stream.c", "include/", "priv/lib/.keepme", "configure", "mix.exs", "mix.lock", "Makefile.mix", "rebar.config", "rebar.config.script", "vars.config.in", "README.md", "LICENSE.txt"]},
   {licenses, ["Apache 2.0"]},
   {links, [{"Github", "https://github.com/processone/fast_xml"}]}]}.
 


### PR DESCRIPTION
'configure' and 'vars.config.in' are required to build as ejabberd
dependencies with rebar3