### PR TITLE
Add 'use_maps' option to fxml_stream.parse_element/2.

### DIFF
--- a/src/fxml_stream.erl
+++ b/src/fxml_stream.erl
@@ -30,7 +30,7 @@
 -on_load(init/0).
 
 -export([new/1, new/2, new/3, parse/2, close/1, reset/1,
-	 change_callback_pid/2, parse_element/1]).
+	 change_callback_pid/2, parse_element/1, parse_element/2]).
 
 -export([load_nif/0, load_nif/1]).
 
@@ -112,4 +112,10 @@ close(_State) ->
                                  {error, {integer(), binary()}}.
 
 parse_element(_Str) ->
+    erlang:nif_error(nif_not_loaded).
+
+-spec parse_element(binary(), [use_maps]) -> xmlel() |
+                                             {error, atom()} |
+                                             {error, {integer(), binary()}}.
+parse_element(_Str, _Options) ->
     erlang:nif_error(nif_not_loaded).

--- a/test/fxml_test.erl
+++ b/test/fxml_test.erl
@@ -121,6 +121,9 @@ tag_with_tags_test() ->
 				    {xmlcdata, <<"cdata2">>}]},
 		 fxml_stream:parse_element(<<"<root><a/>cdata1<b/>cdata2</root>">>)).
 
+use_maps_test() ->
+    ?assertEqual(#{'__struct__' => 'Elixir.FastXML.El', name => <<"root">>, attrs => #{}, children => []}, fxml_stream:parse_element(<<"<root></root>">>, [use_maps])).
+
 receiver(Acc) ->
     receive
 	{'$gen_event', Msg} ->


### PR DESCRIPTION
I'm attempting to surface the elixir structs for my project and thought this would be useful.